### PR TITLE
feat: support glob pattern for wds

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,10 +8,27 @@ const glob = require('fast-glob');
 
 const wds = process.env.wds.split(',');
 
+async function getWds() {
+  return (
+    await Promise.all(
+      wds.map(
+        async (wd) =>
+          await glob(wd, {
+            cwd: '/',
+            onlyDirectories: true,
+            dot: true,
+          }),
+      ),
+    )
+  ).flat();
+}
+
 async function updateProjectsCache() {
+  const matches = await getWds();
+
   const projects = (
     await Promise.all(
-      wds.map(async function (wd) {
+      matches.map(async function (wd) {
         const names = await glob('*', {
           cwd: wd,
           onlyDirectories: true,


### PR DESCRIPTION
Support glob pattern wds using already imported `fast-glob` library.

Previously, to search inside directory I had to register with `wds` as follows:

```
/Users/younho9/repositories/temp,
/Users/younho9/repositories/github,
/Users/younho9/repositories/github/organization,
/Users/younho9/repositories/github/private,
/Users/younho9/repositories/github/public,
/Users/younho9/repositories/company,
/Users/younho9/repositories/company/foo,
/Users/younho9/repositories/company/bar,
/Users/younho9/repositories/company/baz,
...
```

Now, I can reduce `wds` as follows.

```
/Users/younho9/repositories/*
/Users/younho9/repositories/github/*,
/Users/younho9/repositories/company/*,
```

> ⚠️ warning: If a pattern like '**/*' is used, it can be extremely slow. (ex. Search all folders inside the `node_modules` folder.)

resolve #10